### PR TITLE
feat(route): Adiciona respawn automático por falha de rota

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -220,7 +220,8 @@ route_avoidWalls 1
 route_randomWalk 1
 route_randomWalk_inTown 0
 route_randomWalk_maxRouteTime 75
-route_maxWarpFee
+route_maxWarpFee 0
+route_maxRouteErrors 5
 route_maxNpcTries 5
 route_teleport 0
 route_teleport_minDistance 75


### PR DESCRIPTION
feat(route): Implementa mecanismo de recuperação anti-travamento

O bot poderia ficar permanentemente preso em mapas com portais
quebrados ou com dados de rota incorretos, exigindo intervenção manual.

Este commit introduz um sistema que conta as falhas consecutivas
no cálculo de rota. Ao atingir um limite configurável (via
'route_maxRouteErrors' no config.txt), o comando 'respawn' é
executado para forçar a recuperação do bot, movendo-o para
a cidade salva.