### PR TITLE
fix xkore 3 for latam

### DIFF
--- a/src/Network/MessageTokenizer.pm
+++ b/src/Network/MessageTokenizer.pm
@@ -211,7 +211,7 @@ sub slicePacket {
 	if ( defined($$additional_data) && length($$additional_data) > 0 && $::net->getState() >= 4 ) {		
 		my $checksum_byte = substr($$additional_data, 0, 1);
 		$$additional_data = substr($$additional_data, 1);
-		message TF("Removed checksum byte %s from %s [%d bytes] [additional data: %d bytes]\n", unpack("H*", $checksum_byte), $switch, length($packet), length($$additional_data)), "connection";
+		debug TF("Removed checksum byte %s from %s [%d bytes] [additional data: %d bytes]\n", unpack("H*", $checksum_byte), $switch, length($packet), length($$additional_data)), "connection";
 	}
 
 	return $packet; # real packet

--- a/src/Network/MessageTokenizer.pm
+++ b/src/Network/MessageTokenizer.pm
@@ -25,6 +25,8 @@ use Modules 'register';
 use bytes;
 no encoding 'utf8';
 use enum qw(KNOWN_MESSAGE UNKNOWN_MESSAGE ACCOUNT_ID);
+use Translation qw(T TF);
+use Log qw(message warning error debug);
 
 ##
 # Network::MessageTokenizer->new(Hash* rpackets)
@@ -204,6 +206,14 @@ sub slicePacket {
 			}
 		}
 	}
+
+	# Remove checksum byte from the packet we just read if connected to map server (ref: LatamChecksum.pl)
+	if ( defined($$additional_data) && length($$additional_data) > 0 && $::net->getState() >= 4 ) {		
+		my $checksum_byte = substr($$additional_data, 0, 1);
+		$$additional_data = substr($$additional_data, 1);
+		message TF("Removed checksum byte %s from %s [%d bytes] [additional data: %d bytes]\n", unpack("H*", $checksum_byte), $switch, length($packet), length($$additional_data)), "connection";
+	}
+
 	return $packet; # real packet
 }
 

--- a/src/Network/XKoreProxy.pm
+++ b/src/Network/XKoreProxy.pm
@@ -194,7 +194,7 @@ sub serverSend {
 			# Generate otp
 			my $generated_otp;
 			Plugins::callHook('request_otp_login', { otp => \$generated_otp, seed => $config{otpSeed} });
-			warning "generated OTP $generated_otp\n", "xkoreProxy";
+			debug "Generated OTP $generated_otp\n", "xkoreProxy";
 			# Rebuild send otp login packet
 			$msg = $messageSender->reconstruct({
 				switch => "send_otp_login",


### PR DESCRIPTION
Corrige o parsing dos packets para o xKore 3:

- adicionada condição ao receber o packet 0A03 (token_received) ~~para somente iniciar o fluxo de connect quando quando o login_type recebido for 0 (i.e. recebeu o token)~~ para não fechar conexão com o token server se o `login_type` recebido for relacionado a OTP.
- ~~adicionada alteração no packet do OTP para inserir um otp válido.~~
- alterado para já enviar OTP automaticamente após email/senha caso tenha um `otpSeed` válido no `config.txt`.
- corrigido envio do packet de account info.
- ao entrar no map server, adicionada logica para retirar o byte do checksum de todos os packets enviados pelo cliente.