### PR TITLE
LATAM Translate

### DIFF
--- a/plugins/LATAMTranslate/LATAMTranslate.pl
+++ b/plugins/LATAMTranslate/LATAMTranslate.pl
@@ -104,7 +104,7 @@ sub npcTalkPre {
     my ( $self, $args ) = @_;
     my $message = $args->{msg} || '';
 
-    my @tokens = $message =~ /\x1C(.*?)\x1C/g;
+    my @tokens = $message =~ /\x1C(.[A-Za-z0-9])\x1C/g;
 
     if (@tokens) {
         my $last_token = $tokens[-1];
@@ -124,7 +124,7 @@ sub npcTalkRespPre {
 	#message Misc::visualDump($raw_msg);
 
     my $translated = $raw_msg;
-    $translated =~ s/\x1C(.*?)\x1C/translate_token($1)/ge;
+    $translated =~ s/\x1C(.[A-Za-z0-9])\x1C/translate_token($1)/ge;
     my $new_size = length($translated);
     substr($translated, 2, 2, pack('v', $new_size));
 


### PR DESCRIPTION
# Changelog

- Fixed logic to get the npc dialog test code to be translated.

# Problema

A lógica no diálogo dos NPCs é extrair o código dos diálogos que serão traduziados entre 0x1C, entretanto em alguns casos esse 0x1C pode aparecer por outros motivos dentro do pacote recebido, no caso peguei um bug onde pode travar o client e dar disconnect ao falar com o guia de izlude_c, acredito que seja por conta do mapa, pois outro personagem rodando o macro ao falar com o Guia não dá problema. Notei esse 0x1C no pacote executando o debug.

# Solução

O ajuste consite em ao invés de considerar o regexe para buscar **0x1C(qualquer-coisa)0x1C** trocar esse qualquer-coisa apenas para números e letras, esse padrão encontrei olhando em **plugins\LATAMTranslate\string.json**, usei o Cody pra fazer a análise das chaves, por que tem muitas, mas pelo que vi por cima também parece bater esse pattern.

# Nota

Várias conversas começaram a ser traduzidas também, como a Kafra por exemplo.

# Evidências

> Guia - Antes
![image](https://github.com/user-attachments/assets/2f2d4628-2cf6-49c1-baab-77f2e54da30e)

> Guia - Depois
![image](https://github.com/user-attachments/assets/df7d6530-a448-485c-9c12-01b9a9f64487)

> Kafra - Antes
![image](https://github.com/user-attachments/assets/178de6a1-58b8-4fb5-876f-e35c6a7bf5ca)

> Kafra - Depois
![image](https://github.com/user-attachments/assets/742a43b4-bce3-4e4a-8946-f7e77f74c769)
